### PR TITLE
Upgrade Jinja2 to 2.10.1

### DIFF
--- a/requirements/compiled.txt
+++ b/requirements/compiled.txt
@@ -1,2 +1,2 @@
 MySQL-python==1.2.3c1
-Jinja2==2.5.5
+Jinja2>=2.10.1


### PR DESCRIPTION
Mitigate [CVE-2016-10745](https://github.com/advisories/GHSA-hj2j-77xm-mc5v) and [CVE-2019-10906](https://github.com/advisories/GHSA-462w-v97r-4m45). `str.format_map` and `str.format` allow a sandbox escape.

Though webowonder doesn't use `str.format_map` it does use `str.format`.

I can't tell if the user can control the payload in this location

https://github.com/mozilla/webowonder/blob/9fa31e64db1411839397b3cea09279540538b190/apps/wow/views.py

If so, this could result in an exploit